### PR TITLE
Support different Confluence URL patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ jobs:
 
 Uses basic auth for the rest api.
 
-- `cloud`: The ID can be found by looking at your confluence domain: `https://<cloud>.atlassian.net/...`
+- `cloudUrl`: The URL (without https://) of your confluence instance. E.g: `acme.atlassian.net/...` or `acme.jira.com`
 
 - `user`: The user that generated the access token
 
 - `token`: You can generate the token [here](https://id.atlassian.com/manage-profile/security/api-tokens). Link to [Docs](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)
 
-- `to`: The page ID can be found by simply navigating to the page where you want the content to be postet to and looke at the url. It will look something like this: `https://<cloud-id>.atlassian.net/wiki/spaces/<space>/pages/<page-id>/<title>`
+- `to`: The page ID can be found by simply navigating to the page where you want the content to be postet to and looke at the url. It will look something like this: `https://<cloudUrl>/wiki/spaces/<space>/pages/<page-id>/<title>`
 
 ### Using secrets
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
 Uses basic auth for the rest api.
 
 - `cloud`: Can be either:
-  - A subdomain (e.g., `acme` for Atlassian hosted instances)
+  - A subdomain (`acme` for Atlassian hosted instances (e.g. `https://acme.atlassian.net`))
   - A full URL (e.g., `https://mycompany.com` for self-hosted instances)
 
 - `user`: The user that generated the access token

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ jobs:
 
 Uses basic auth for the rest api.
 
-- `cloudUrl`: The URL (without https://) of your confluence instance. E.g: `acme.atlassian.net/...` or `acme.jira.com`
+- `cloud`: Can be either:
+  - A subdomain (e.g., `acme` for Atlassian hosted instances)
+  - A full URL (e.g., `https://mycompany.com` for self-hosted instances)
 
 - `user`: The user that generated the access token
 
 - `token`: You can generate the token [here](https://id.atlassian.com/manage-profile/security/api-tokens). Link to [Docs](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)
 
-- `to`: The page ID can be found by simply navigating to the page where you want the content to be postet to and looke at the url. It will look something like this: `https://<cloudUrl>/wiki/spaces/<space>/pages/<page-id>/<title>`
+- `to`: The page ID can be found by simply navigating to the page where you want the content to be posted to and look at the url. It will look something like this: 
+  - For Atlassian hosted: `https://<subdomain>.atlassian.net/wiki/spaces/<space>/pages/<page-id>/<title>`
+  - For self-hosted: `https://<your-url>/wiki/spaces/<space>/pages/<page-id>/<title>`
 
 ### Using secrets
 

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ if not workspace:
     exit(1)
 
 envs: Dict[str, str] = {}
-for key in ['from', 'to', 'cloudUrl', 'user', 'token']:
+for key in ['from', 'to', 'cloud', 'user', 'token']:
     value = environ.get(f'INPUT_{key.upper()}')
     if not value:
         print(f'Missing value for {key}')
@@ -25,7 +25,13 @@ for key in ['from', 'to', 'cloudUrl', 'user', 'token']:
 with open(join(workspace, envs['from'])) as f:
     md = f.read()
 
-url = f"https://{envs['cloudUrl']}/wiki/rest/api/content/{envs['to']}"
+base_url = envs['cloud']
+if '://' in base_url:  # It's a full URL
+    # Remove trailing slash if present
+    base_url = base_url.rstrip('/')
+    url = f"{base_url}/wiki/rest/api/content/{envs['to']}"
+else:  # It's a subdomain
+    url = f"https://{base_url}.atlassian.net/wiki/rest/api/content/{envs['to']}"
 
 current = requests.get(url, auth=(envs['user'], envs['token'])).json()
 

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ if not workspace:
     exit(1)
 
 envs: Dict[str, str] = {}
-for key in ['from', 'to', 'cloud', 'user', 'token']:
+for key in ['from', 'to', 'cloudUrl', 'user', 'token']:
     value = environ.get(f'INPUT_{key.upper()}')
     if not value:
         print(f'Missing value for {key}')
@@ -25,7 +25,7 @@ for key in ['from', 'to', 'cloud', 'user', 'token']:
 with open(join(workspace, envs['from'])) as f:
     md = f.read()
 
-url = f"https://{envs['cloud']}.atlassian.net/wiki/rest/api/content/{envs['to']}"
+url = f"https://{envs['cloudUrl']}/wiki/rest/api/content/{envs['to']}"
 
 current = requests.get(url, auth=(envs['user'], envs['token'])).json()
 


### PR DESCRIPTION
modified `cloud` to support both subdomains (*.atlassian.net) or actual domains (e.g. ame.jira.com).