### PR TITLE
Improve error handling on authentication failure

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -33,7 +33,9 @@ if '://' in base_url:  # It's a full URL
 else:  # It's a subdomain
     url = f"https://{base_url}.atlassian.net/wiki/rest/api/content/{envs['to']}"
 
-current = requests.get(url, auth=(envs['user'], envs['token'])).json()
+response = requests.get(url, auth=(envs['user'], envs['token']))
+response.raise_for_status()
+current = response.json()
 
 html = markdown(md, extensions=[GithubFlavoredMarkdownExtension()])
 content = {


### PR DESCRIPTION
When incorrect credentials are supplied, it's hard to reason this from the error produced:
```
% GITHUB_WORKSPACE=. \
INPUT_FROM=readme.md \
INPUT_TO=1 \
INPUT_CLOUD=hazelcast \
INPUT_USER=user@example.com \
INPUT_TOKEN=incorrect-token \
python3 src/main.py
Traceback (most recent call last):
  File "confluence-markdown-sync/src/main.py", line 47, in <module>
    'id': current['id'],
KeyError: 'id'
```

Instead, by checking the response we get a _hint_ where the problem might be:
```
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://hazelcast.atlassian.net/wiki/rest/api/content/1
```